### PR TITLE
Add new option for splitting search string

### DIFF
--- a/docs/components/NoSplitSearchResults.vue
+++ b/docs/components/NoSplitSearchResults.vue
@@ -1,0 +1,19 @@
+<template>
+  <treeselect
+    :options="options"
+    :multiple="true"
+    :search-split-words="false"
+    :flatten-search-results="false"
+    placeholder="Where are you from?"
+    />
+</template>
+
+<script>
+  import countries from './data/countries-of-the-world'
+
+  export default {
+    data: () => ({
+      options: countries,
+    }),
+  }
+</script>

--- a/docs/partials/guides.pug
+++ b/docs/partials/guides.pug
@@ -94,6 +94,11 @@
     Set `flattenSearchResults: true` to flatten the tree when searching. With this option set to `true`, only the results that match will be shown. With this set to `false` (default), its ancestors will also be displayed, even if they would not individually be included in the results.
   +demo('FlattenSearchResults')
 
++subsection('Prevent split search')
+  :markdown-it
+    Set `searchSplitWords: false` to not split the search text by space (words) and look up words matches. When `false` it will look up the whole search text.
+  +demo('NoSplitSearchResults')
+
 +subsection('Disable Item Selection')
   :markdown-it
     You can disable item selection by setting `isDisabled: true` on any leaf node or branch node. For non-flat mode, setting on a branch node will disable all its descendants as well.

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -535,6 +535,14 @@ export default {
     },
 
     /**
+     * Search in ancestor nodes too.
+     */
+    searchSplitWords: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * Whether to show a children count next to the label of each branch node.
      */
     showCount: {
@@ -1222,8 +1230,10 @@ export default {
         }
       })
 
-      const lowerCasedSearchQuery = searchQuery.trim().toLocaleLowerCase()
-      const splitSearchQuery = lowerCasedSearchQuery.replace(/\s+/g, ' ').split(' ')
+      const lowerCasedSearchQuery = searchQuery.toLocaleLowerCase().replace(/\s+/g, ' ')
+      const splitSearchQuery = this.searchSplitWords
+        ? lowerCasedSearchQuery.trim().split(' ')
+        : [ lowerCasedSearchQuery ]
       this.traverseAllNodesDFS(node => {
         if (this.searchNested && splitSearchQuery.length > 1) {
           node.isMatched = splitSearchQuery.every(filterValue =>

--- a/src/utils/includes.js
+++ b/src/utils/includes.js
@@ -1,3 +1,3 @@
 export function includes(arrOrStr, elem) {
-  return arrOrStr.indexOf(elem) !== -1
+  return arrOrStr.includes(elem)
 }


### PR DESCRIPTION
When passed as false it will use the full text, along with spaces